### PR TITLE
Feature/parametrize update

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ print(things.get(owner="Johnny"))
 
 #### order_by
 
-`order_by` accepts one or more field names. Prepending a `"-"` to the field name will reverse the ordering for that field,
+`order_by` accepts one or more field names. Prepending a `"-"` to the field name will reverse the ordering for that
+field,
 just like in Django.
 
 ```python
@@ -213,13 +214,16 @@ This is a thin wrapper around `pytest.mark.parametrize` that provides better ove
 Consider the following (totally useless) test:
 
 ```python
+import pytest
+
+
 @pytest.mark.parametrize(
     "a, b, c, d, e, f, g, h, i",
     [
-        (True, 2, "foo", [], (), 69, 7, 8, ...),
-        (False, 2, "bar", [], (), 420, 7, 8, ...),
-        (None, 2, "baz", [], (), 666, 7, 8, ...),
-        (True, 2, "baz", [], (), 9000, 7, 8, ...),
+        pytest.param(True, 2, "foo", [], (), 69, 7, 8, ...),
+        pytest.param(False, 2, "bar", [], (), 420, 7, 8, ...),
+        pytest.param(None, 2, "baz", [], (), 666, 7, 8, ...),
+        pytest.param(True, 2, "baz", [], (), 9000, 7, 8, ...),
     ],
 )
 def test_parametrize(a, b, c, d, e, f, g, h, i):
@@ -238,38 +242,37 @@ It was difficult to write because I couldn't quickly see which parameter name ma
 test using my parametrize wrapper:
 
 ```python
-from redbreast.testing import parametrize, testparams
+import redbreast
 
 
-@parametrize(
-    param := testparams("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+@redbreast.parametrize(
+    "a, b, c, d, e, f, g, h, i",
     [
-        param(a=True, b=2, c="foo", d=[], e=(), f=69, g=7, h=8, i=...),
-        param(a=False, b=2, c="bar", d=[], e=(), f=420, g=7, h=8, i=...),
-        param(a=None, b=2, c="baz", d=[], e=(), f=666, g=7, h=8, i=...),
-        param(a=True, b=2, c="baz", d=[], e=(), f=9000, g=7, h=8, i=...),
+        redbreast.param(a=True, b=2, c="foo", d=[], e=(), f=69, g=7, h=8, i=...),
+        redbreast.param(a=False, b=2, c="bar", d=[], e=(), f=420, g=7, h=8, i=...),
+        redbreast.param(a=None, b=2, c="baz", d=[], e=(), f=666, g=7, h=8, i=...),
+        redbreast.param(a=True, b=2, c="baz", d=[], e=(), f=9000, g=7, h=8, i=...),
     ],
 )
-def test_parametrize(param):
-    assert param.a in [True, False, None]
-    assert param.b == 2
-    assert isinstance(param.c, str)
-    assert isinstance(param.d, list) and len(param.d) == 0
-    assert isinstance(param.e, tuple) and len(param.e) == 0
-    assert isinstance(param.f, int)
-    assert param.g == 7
-    assert param.h == 8
-    assert param.i == Ellipsis
+def test_parametrize(a, b, c, d, e, f, g, h, i):
+    assert a in [True, False, None]
+    assert b == 2
+    assert isinstance(c, str)
+    assert isinstance(d, list) and len(d) == 0
+    assert isinstance(e, tuple) and len(e) == 0
+    assert isinstance(f, int)
+    assert g == 7
+    assert h == 8
+    assert i == Ellipsis
 ```
 
 Much better. I can see at a glance that `g=7`, for example.
 
-By invoking `param := testparams("a", "b", "c", ...)` we are creating a dataclass on the fly, which accepts
-arguments `"a", "b", "c", ...`, and acts as our container for each test case. All arguments are optional, and default
-to `None` if no value is supplied. Only keyword arguments are allowed, because the whole point is to make the test more
+`redbreast.param` is a container that mimics `pytest.param`, except that it forces us to use keyword arguments.
+Only keyword arguments are allowed, because the whole point is to make the test more
 descriptive. Using positional args -- `param(1, 2, 3, ...)` -- is not allowed.
 
-The dataclass has the default argument `description` to encourage you to describe each test case. The description is
+Like `pytest.param`, `redbreast.param` has the `id` argument which can be used to describe the test. `id` is
 also passed to pytest so that it shows up nicely in output. By default, pytest tries to generate a description based on
 the items in the list:
 
@@ -283,16 +286,19 @@ the items in the list:
 If we pass the following descriptions, they will show up in the output instead:
 
 ```python
-@parametrize(
-    param := testparams("a", "b", "c", "d", "e", "f", "g", "h", "i"),
+import redbreast
+
+
+@redbreast.parametrize(
+    "a, b, c, d, e, f, g, h, i",
     [
-        param(description="1st test case", ...),
-        param(description="2nd test case", ...),
-        param(description="3rd test case", ...),
-        param(description="4th test case", ...),
+        redbreast.param(id="1st test case", ...),
+        redbreast.param(id="2nd test case", ...),
+        redbreast.param(id="3rd test case", ...),
+        redbreast.param(id="4th test case", ...),
     ],
 )
-def test_parametrize(param):
+def test_parametrize(a, b, c, d, e, f, g, h, i):
     ...
 
 # ============================= test session starts ==============================

--- a/redbreast/__init__.py
+++ b/redbreast/__init__.py
@@ -1,0 +1,1 @@
+from .testing import param, parametrize

--- a/redbreast/testing.py
+++ b/redbreast/testing.py
@@ -53,9 +53,7 @@ def parametrize(argnames: str | Sequence[str], params: Sequence[param], **kwargs
         expected_args = set(argnames)
         passed_kwargs = set(p.kwargs.keys())
         if missing := expected_args.difference(passed_kwargs):
-            raise TypeError(
-                f"Param with id={p.id!r} is missing these kwargs: {sorted(missing)}"
-            )
+            raise TypeError(f"Param with id={p.id!r} is missing these kwargs: {sorted(missing)}")
         if unexpected := passed_kwargs.difference(expected_args):
             raise TypeError(
                 f"Param with id={p.id!r} received unexpected kwargs: {sorted(unexpected)}"
@@ -95,9 +93,7 @@ def assert_dicts_equal(a: dict, b: dict):
         return
 
     keys_diff = set_difference(a.keys(), b.keys())
-    assert (
-        not keys_diff
-    ), f"These keys are not present in both dictionaries: {sorted(keys_diff)}"
+    assert not keys_diff, f"These keys are not present in both dictionaries: {sorted(keys_diff)}"
     for key, a_value in a.items():
         b_value = b[key]
         if isinstance(a_value, dict) and isinstance(b_value, dict):

--- a/redbreast/testing.py
+++ b/redbreast/testing.py
@@ -1,7 +1,8 @@
 """Utility stuff for use in tests"""
+
 import operator
-from dataclasses import make_dataclass
-from typing import Any, Optional, Protocol
+import re
+from typing import Optional, Protocol, Sequence
 
 import pytest
 
@@ -15,24 +16,56 @@ class TestParams(Protocol):
         ...
 
 
-def parametrize(param_class: TestParams, values_list, *args, **kwargs):
-    """Thin wrapper around pytest.mark.parametrize, which helps enforce keyword
-    arguments in the parameters"""
-    # the `id` field is what pycharm displays as the description for each individual test case.
-    # Pytest usually auto-generates these (badly)
-    values_list = [pytest.param(value, id=value.description) for value in values_list]
-    return pytest.mark.parametrize("param", values_list, *args, **kwargs)
+class param:
+    """
+    Shadows pytest.param, but the values go in the **kwargs, not the *args.
+    """
+
+    def __init__(
+        self,
+        *,  # force kwargs
+        marks: tuple = (),
+        id: Optional[str] = None,
+        **kwargs,
+    ):
+        self.marks = marks
+        self.id = id
+        self.kwargs = kwargs
 
 
-def testparams(*field_names) -> type[TestParams]:
-    """Generates a dataclass to hold the given test parameters. The `description` field is always
-    included, so we don't have to define it every time we write a test. Keyword arguments are
-    enforced for readability. Typing is set to Optional[Any] for all fields, to keep the syntax
-    as simple as possible (and anyway, PyCharm doesn't pick up any type hints from this generated
-    class)."""
-    field_names = field_names + ("description",)
-    fields = [(name, Optional[Any], None) for name in field_names]
-    return make_dataclass(cls_name="testparams", fields=fields)
+def parametrize(argnames: str | Sequence[str], params: Sequence[param], **kwargs):
+    """
+    Wraps pytest.mark.parametrize.
+    Unpacks the redbreast.params into pytest.params with positional arguments.
+    """
+
+    # convert argnames to a list of strings.
+    # This dictates the order in which the values should appear.
+    if isinstance(argnames, str):
+        argnames = re.split(", |,", argnames)  # match comma+space and comma
+    else:
+        argnames = list(argnames)
+
+    # convert the list of redbreast.params into pytest.params
+    argvalues = []
+    for p in params:
+        # check the param.kwargs exactly match the required argnames
+        expected_args = set(argnames)
+        passed_kwargs = set(p.kwargs.keys())
+        if missing := expected_args.difference(passed_kwargs):
+            raise TypeError(
+                f"Param with id={p.id!r} is missing these kwargs: {sorted(missing)}"
+            )
+        if unexpected := passed_kwargs.difference(expected_args):
+            raise TypeError(
+                f"Param with id={p.id!r} received unexpected kwargs: {sorted(unexpected)}"
+            )
+
+        # Get the positional args in the correct order (matching the order of argnames)
+        values = [p.kwargs.get(n) for n in argnames]
+        arg_value = pytest.param(*values, marks=p.marks, id=p.id)
+        argvalues.append(arg_value)
+    return pytest.mark.parametrize(argnames, argvalues, **kwargs)
 
 
 def set_difference(a, b):
@@ -62,7 +95,9 @@ def assert_dicts_equal(a: dict, b: dict):
         return
 
     keys_diff = set_difference(a.keys(), b.keys())
-    assert not keys_diff, f"These keys are not present in both dictionaries: {sorted(keys_diff)}"
+    assert (
+        not keys_diff
+    ), f"These keys are not present in both dictionaries: {sorted(keys_diff)}"
     for key, a_value in a.items():
         b_value = b[key]
         if isinstance(a_value, dict) and isinstance(b_value, dict):


### PR DESCRIPTION
Made parametrize more compatible with pytest's own `param`. We no longer use the TestParams protocol. 